### PR TITLE
Actually materialize example models as table

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -35,4 +35,4 @@ models:
   my_new_project:
       # Applies to all files under models/example/
       example:
-          materialized: view
+          materialized: table

--- a/models/example/my_second_dbt_model.sql
+++ b/models/example/my_second_dbt_model.sql
@@ -1,4 +1,4 @@
-
+{{ config(materialized='view') }}
 -- Use the `ref` function to select from other models
 
 select *


### PR DESCRIPTION
According to `dbt-project.yml`,

> In this example config, we tell dbt to build all models in the example/ directory as tables.

But then proceeds to set `+materialized: view`, which is just repeating the default.

This PR changes the default config to actually materialize as table by default, and then overrides the materialization to view in `my_second_dbt_model.sql` (so the end result of dbt run remains unchanged)

Tested with: dbt 1.3.2 and snowflake 1.3.0